### PR TITLE
Fix Just Lift summary reset race

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -6996,7 +6996,11 @@ class ActiveSessionEngine(
 
     // ===== Core Workout Lifecycle =====
 
-    fun resetForNewWorkout(expectedLease: ExecutionLease? = null): Boolean {
+    fun resetForNewWorkout() {
+        resetForNewWorkoutInternal(null)
+    }
+
+    private fun resetForNewWorkoutInternal(expectedLease: ExecutionLease?): Boolean {
         val cleanupCandidate = runtimeCleanupCandidateRef.value
         val restoredTimerOwner = restoredRestTimerOwnerRef.value
         val resetToken = executionGuard.supersedeRecoveryPublicationAndCaptureResetCleanupToken()
@@ -11332,7 +11336,7 @@ class ActiveSessionEngine(
 
                 if (skipSummary) {
                     Logger.d("Just Lift: Summary OFF - skipping summary")
-                    if (!resetForNewWorkout(lease)) return@launchCompletionJob
+                    if (!resetForNewWorkoutInternal(lease)) return@launchCompletionJob
                     coordinator._workoutState.value = WorkoutState.Idle
                     if (justLiftRestSeconds > 0) {
                         startJustLiftEggTimer(justLiftRestSeconds)
@@ -11343,7 +11347,7 @@ class ActiveSessionEngine(
 
                     if (coordinator._workoutState.value is WorkoutState.SetSummary) {
                         Logger.d("Just Lift: Summary complete, transitioning to Idle")
-                        if (!resetForNewWorkout(lease)) return@launchCompletionJob
+                        if (!resetForNewWorkoutInternal(lease)) return@launchCompletionJob
                         coordinator._workoutState.value = WorkoutState.Idle
                         if (justLiftRestSeconds > 0) {
                             Logger.d("Just Lift: Starting egg timer ($justLiftRestSeconds s)")

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -4321,6 +4321,7 @@ class ActiveSessionEngine(
     internal var beforePersistedRestTimerActionForTest: (suspend () -> Unit)? = null
     internal var afterPersistedRestTimerActionAuthorizationForTest: (suspend () -> Unit)? = null
     internal var afterResetCleanupTokenCaptureForTest: (() -> Unit)? = null
+    internal var afterJustLiftResetPresentationForTest: (() -> Unit)? = null
     internal var recoveryPreparationCallsForTest: Int = 0
     internal var afterRuntimeResumeSelectionForTest: (suspend (RoutineResumeHandle.Persisted) -> Unit)? = null
     internal var beforeRestoredRuntimeOwnerPublicationForTest: (() -> Unit)? = null
@@ -7000,73 +7001,83 @@ class ActiveSessionEngine(
         resetForNewWorkoutInternal(null)
     }
 
-    private fun resetForNewWorkoutInternal(expectedLease: ExecutionLease?): Boolean {
+    internal fun resetForNewWorkoutForTest(expectedLease: ExecutionLease): Boolean =
+        resetForNewWorkoutInternal(expectedLease)
+
+    private fun resetForNewWorkoutInternal(
+        expectedLease: ExecutionLease?,
+        afterExpectedLeaseReset: (() -> Unit)? = null,
+    ): Boolean {
         val expectedResetToken = expectedLease?.let { lease ->
             executionGuard.claimExpectedResetAndCaptureResetCleanupToken(lease)
                 ?: return false
         }
-        val cleanupCandidate = runtimeCleanupCandidateRef.value
-        val restoredTimerOwner = restoredRestTimerOwnerRef.value
-        val resetToken = expectedResetToken
-            ?: executionGuard.supersedeRecoveryPublicationAndCaptureResetCleanupToken()
-        val cleanupTarget = cleanupCandidate?.let { candidate ->
-            installRuntimeCleanupIntent(
-                captureRuntimeCleanupTarget(candidate, RuntimeCleanupReason.EXPLICIT_RESTART),
-            )
-        }
-        executionGuard.supersedeQueuedSuccessors()
-        supersedePendingResetStart()
-        cleanupTarget?.let(::launchRuntimeCleanup)
-        if (acceptedRetryStartClaim.value != null && coordinator.workoutJob?.isActive == true) {
+        try {
+            val cleanupCandidate = runtimeCleanupCandidateRef.value
+            val restoredTimerOwner = restoredRestTimerOwnerRef.value
+            val resetToken = expectedResetToken
+                ?: executionGuard.supersedeRecoveryPublicationAndCaptureResetCleanupToken()
+            val cleanupTarget = cleanupCandidate?.let { candidate ->
+                installRuntimeCleanupIntent(
+                    captureRuntimeCleanupTarget(candidate, RuntimeCleanupReason.EXPLICIT_RESTART),
+                )
+            }
+            executionGuard.supersedeQueuedSuccessors()
+            supersedePendingResetStart()
+            cleanupTarget?.let(::launchRuntimeCleanup)
+            if (acceptedRetryStartClaim.value != null && coordinator.workoutJob?.isActive == true) {
+                afterResetCleanupTokenCaptureForTest?.invoke()
+                restoredTimerOwner?.let(::detachRestoredRestTimerIfExact)?.cancel()
+                coordinator.workoutJob?.cancel(CancellationException("Accepted retry reset requested"))
+                afterExpectedLeaseReset?.invoke()
+                return true
+            }
+            val lease = resetToken.lease
             afterResetCleanupTokenCaptureForTest?.invoke()
             restoredTimerOwner?.let(::detachRestoredRestTimerIfExact)?.cancel()
-            coordinator.workoutJob?.cancel(CancellationException("Accepted retry reset requested"))
-            expectedLease?.let(executionGuard::releaseExpectedResetClaim)
+            coordinator.workoutJob?.cancel(CancellationException("Workout reset requested"))
+            coordinator.workoutJob = null
+            lease?.let(bodyweightCompletionGate::invalidate)
+            lease?.let(::clearDangerZoneCountdownOverride)
+            if (lease?.requiresMachine == true) {
+                val resetOwner = ResetMachineTeardownOwner(
+                    id = resetMachineTeardownOwnerSequence.incrementAndGet(),
+                    lease = lease,
+                )
+                if (resetMachineTeardownOwner.compareAndSet(null, resetOwner) &&
+                    !beginMachineTeardown(lease, TeardownReason.RECOVERY)
+                ) {
+                    resetMachineTeardownOwner.compareAndSet(resetOwner, null)
+                }
+            }
+            val invalidatedLease = if (expectedLease != null) {
+                lease
+            } else {
+                lease?.takeIf {
+                    executionGuard.invalidate(it, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)
+                }
+            }
+            lease?.let(::discardTeardownReadyContinuation)
+            if (invalidatedLease != null) {
+                afterResetInvalidation(invalidatedLease.executionId, invalidatedLease.sessionId)
+                repFreshnessGate.invalidate(invalidatedLease)
+                detachBiomechanicsContext(invalidatedLease)
+                if (executionContext?.lease?.sameExecutionAs(invalidatedLease) == true) {
+                    executionContext = null
+                }
+            }
+            if (lease != null && invalidatedLease == null) {
+                afterExpectedLeaseReset?.invoke()
+                return true
+            }
+            executionGuard.commitResetCleanupIfNoSuccessor(resetToken, invalidatedLease) {
+                clearSharedStateForNewWorkout()
+            }
+            afterExpectedLeaseReset?.invoke()
             return true
-        }
-        val lease = resetToken.lease
-        afterResetCleanupTokenCaptureForTest?.invoke()
-        restoredTimerOwner?.let(::detachRestoredRestTimerIfExact)?.cancel()
-        coordinator.workoutJob?.cancel(CancellationException("Workout reset requested"))
-        coordinator.workoutJob = null
-        lease?.let(bodyweightCompletionGate::invalidate)
-        lease?.let(::clearDangerZoneCountdownOverride)
-        if (lease?.requiresMachine == true) {
-            val resetOwner = ResetMachineTeardownOwner(
-                id = resetMachineTeardownOwnerSequence.incrementAndGet(),
-                lease = lease,
-            )
-            if (resetMachineTeardownOwner.compareAndSet(null, resetOwner) &&
-                !beginMachineTeardown(lease, TeardownReason.RECOVERY)
-            ) {
-                resetMachineTeardownOwner.compareAndSet(resetOwner, null)
-            }
-        }
-        val invalidatedLease = if (expectedLease != null) {
-            lease
-        } else {
-            lease?.takeIf {
-                executionGuard.invalidate(it, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)
-            }
-        }
-        lease?.let(::discardTeardownReadyContinuation)
-        if (invalidatedLease != null) {
-            afterResetInvalidation(invalidatedLease.executionId, invalidatedLease.sessionId)
-            repFreshnessGate.invalidate(invalidatedLease)
-            detachBiomechanicsContext(invalidatedLease)
-            if (executionContext?.lease?.sameExecutionAs(invalidatedLease) == true) {
-                executionContext = null
-            }
-        }
-        if (lease != null && invalidatedLease == null) {
+        } finally {
             expectedLease?.let(executionGuard::releaseExpectedResetClaim)
-            return true
         }
-        executionGuard.commitResetCleanupIfNoSuccessor(resetToken, invalidatedLease) {
-            clearSharedStateForNewWorkout()
-        }
-        expectedLease?.let(executionGuard::releaseExpectedResetClaim)
-        return true
     }
 
     private fun clearSharedStateForNewWorkout() {
@@ -11344,23 +11355,29 @@ class ActiveSessionEngine(
 
                 if (skipSummary) {
                     Logger.d("Just Lift: Summary OFF - skipping summary")
-                    if (!resetForNewWorkoutInternal(lease)) return@launchCompletionJob
-                    coordinator._workoutState.value = WorkoutState.Idle
-                    if (justLiftRestSeconds > 0) {
-                        startJustLiftEggTimer(justLiftRestSeconds)
+                    val resetSucceeded = resetForNewWorkoutInternal(lease) {
+                        coordinator._workoutState.value = WorkoutState.Idle
+                        if (justLiftRestSeconds > 0) {
+                            startJustLiftEggTimer(justLiftRestSeconds)
+                        }
+                        afterJustLiftResetPresentationForTest?.invoke()
                     }
+                    if (!resetSucceeded) return@launchCompletionJob
                 } else if (summaryDelayMs > 0) {
                     delay(summaryDelayMs)
                     if (!hasCurrentAuthority(lease, "just_lift_summary_delay")) return@launchCompletionJob
 
                     if (coordinator._workoutState.value is WorkoutState.SetSummary) {
                         Logger.d("Just Lift: Summary complete, transitioning to Idle")
-                        if (!resetForNewWorkoutInternal(lease)) return@launchCompletionJob
-                        coordinator._workoutState.value = WorkoutState.Idle
-                        if (justLiftRestSeconds > 0) {
-                            Logger.d("Just Lift: Starting egg timer ($justLiftRestSeconds s)")
-                            startJustLiftEggTimer(justLiftRestSeconds)
+                        val resetSucceeded = resetForNewWorkoutInternal(lease) {
+                            coordinator._workoutState.value = WorkoutState.Idle
+                            if (justLiftRestSeconds > 0) {
+                                Logger.d("Just Lift: Starting egg timer ($justLiftRestSeconds s)")
+                                startJustLiftEggTimer(justLiftRestSeconds)
+                            }
+                            afterJustLiftResetPresentationForTest?.invoke()
                         }
+                        if (!resetSucceeded) return@launchCompletionJob
                     } else {
                         Logger.d("Just Lift: Summary interrupted by user action (state is ${coordinator._workoutState.value})")
                     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -7001,11 +7001,14 @@ class ActiveSessionEngine(
     }
 
     private fun resetForNewWorkoutInternal(expectedLease: ExecutionLease?): Boolean {
+        val expectedResetToken = expectedLease?.let { lease ->
+            executionGuard.claimExpectedResetAndCaptureResetCleanupToken(lease)
+                ?: return false
+        }
         val cleanupCandidate = runtimeCleanupCandidateRef.value
         val restoredTimerOwner = restoredRestTimerOwnerRef.value
-        val resetToken = executionGuard.supersedeRecoveryPublicationAndCaptureResetCleanupToken()
-        val expectedLeaseClaimed = expectedLease == null || executionGuard.claimExpectedReset(expectedLease)
-        if (!expectedLeaseClaimed) return false
+        val resetToken = expectedResetToken
+            ?: executionGuard.supersedeRecoveryPublicationAndCaptureResetCleanupToken()
         val cleanupTarget = cleanupCandidate?.let { candidate ->
             installRuntimeCleanupIntent(
                 captureRuntimeCleanupTarget(candidate, RuntimeCleanupReason.EXPLICIT_RESTART),
@@ -7018,6 +7021,7 @@ class ActiveSessionEngine(
             afterResetCleanupTokenCaptureForTest?.invoke()
             restoredTimerOwner?.let(::detachRestoredRestTimerIfExact)?.cancel()
             coordinator.workoutJob?.cancel(CancellationException("Accepted retry reset requested"))
+            expectedLease?.let(executionGuard::releaseExpectedResetClaim)
             return true
         }
         val lease = resetToken.lease
@@ -7054,10 +7058,14 @@ class ActiveSessionEngine(
                 executionContext = null
             }
         }
-        if (lease != null && invalidatedLease == null) return true
+        if (lease != null && invalidatedLease == null) {
+            expectedLease?.let(executionGuard::releaseExpectedResetClaim)
+            return true
+        }
         executionGuard.commitResetCleanupIfNoSuccessor(resetToken, invalidatedLease) {
             clearSharedStateForNewWorkout()
         }
+        expectedLease?.let(executionGuard::releaseExpectedResetClaim)
         return true
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -6996,10 +6996,12 @@ class ActiveSessionEngine(
 
     // ===== Core Workout Lifecycle =====
 
-    fun resetForNewWorkout() {
+    fun resetForNewWorkout(expectedLease: ExecutionLease? = null): Boolean {
         val cleanupCandidate = runtimeCleanupCandidateRef.value
         val restoredTimerOwner = restoredRestTimerOwnerRef.value
         val resetToken = executionGuard.supersedeRecoveryPublicationAndCaptureResetCleanupToken()
+        val expectedLeaseClaimed = expectedLease == null || executionGuard.claimExpectedReset(expectedLease)
+        if (!expectedLeaseClaimed) return false
         val cleanupTarget = cleanupCandidate?.let { candidate ->
             installRuntimeCleanupIntent(
                 captureRuntimeCleanupTarget(candidate, RuntimeCleanupReason.EXPLICIT_RESTART),
@@ -7012,7 +7014,7 @@ class ActiveSessionEngine(
             afterResetCleanupTokenCaptureForTest?.invoke()
             restoredTimerOwner?.let(::detachRestoredRestTimerIfExact)?.cancel()
             coordinator.workoutJob?.cancel(CancellationException("Accepted retry reset requested"))
-            return
+            return true
         }
         val lease = resetToken.lease
         afterResetCleanupTokenCaptureForTest?.invoke()
@@ -7032,8 +7034,12 @@ class ActiveSessionEngine(
                 resetMachineTeardownOwner.compareAndSet(resetOwner, null)
             }
         }
-        val invalidatedLease = lease?.takeIf {
-            executionGuard.invalidate(it, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)
+        val invalidatedLease = if (expectedLease != null) {
+            lease
+        } else {
+            lease?.takeIf {
+                executionGuard.invalidate(it, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)
+            }
         }
         lease?.let(::discardTeardownReadyContinuation)
         if (invalidatedLease != null) {
@@ -7044,10 +7050,11 @@ class ActiveSessionEngine(
                 executionContext = null
             }
         }
-        if (lease != null && invalidatedLease == null) return
+        if (lease != null && invalidatedLease == null) return true
         executionGuard.commitResetCleanupIfNoSuccessor(resetToken, invalidatedLease) {
             clearSharedStateForNewWorkout()
         }
+        return true
     }
 
     private fun clearSharedStateForNewWorkout() {
@@ -11325,7 +11332,7 @@ class ActiveSessionEngine(
 
                 if (skipSummary) {
                     Logger.d("Just Lift: Summary OFF - skipping summary")
-                    resetForNewWorkout()
+                    if (!resetForNewWorkout(lease)) return@launchCompletionJob
                     coordinator._workoutState.value = WorkoutState.Idle
                     if (justLiftRestSeconds > 0) {
                         startJustLiftEggTimer(justLiftRestSeconds)
@@ -11336,7 +11343,7 @@ class ActiveSessionEngine(
 
                     if (coordinator._workoutState.value is WorkoutState.SetSummary) {
                         Logger.d("Just Lift: Summary complete, transitioning to Idle")
-                        resetForNewWorkout()
+                        if (!resetForNewWorkout(lease)) return@launchCompletionJob
                         coordinator._workoutState.value = WorkoutState.Idle
                         if (justLiftRestSeconds > 0) {
                             Logger.d("Just Lift: Starting egg timer ($justLiftRestSeconds s)")

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
@@ -203,6 +203,7 @@ internal class WorkoutExecutionGuard(
     private val persistedClaims = LinkedHashMap<String, PersistenceClaimStatus>()
 
     private var teardownLease: ExecutionLease? = null
+    private var expectedResetClaim: ExecutionLease? = null
     private var machineConfigurationClaim: MachineConfigurationClaim? = null
     private var deferredConfigurationTeardownLease: ExecutionLease? = null
     private var deferredConfigurationTeardownAttempt = 0
@@ -386,7 +387,8 @@ internal class WorkoutExecutionGuard(
     }
 
     private fun beginExecutionLocked(seed: ExecutionSeed): Result<ExecutionLease> {
-        if (machineConfigurationClaim != null ||
+        if (expectedResetClaim != null ||
+            machineConfigurationClaim != null ||
             recoveryPublicationClaim != null ||
             queuedSuccessorSetup != null ||
             restoredTeardownRecord != null ||
@@ -905,9 +907,9 @@ internal class WorkoutExecutionGuard(
         invalidated
     }
 
-    fun invalidate(lease: ExecutionLease, reason: ExecutionInvalidationReason): Boolean = withPlatformLock(teardownLock) {
-        val current = currentLeaseRef.value ?: return@withPlatformLock false
-        if (!sameIdentity(current, lease)) return@withPlatformLock false
+    private fun invalidateLocked(lease: ExecutionLease, reason: ExecutionInvalidationReason): Boolean {
+        val current = currentLeaseRef.value ?: return false
+        if (!sameIdentity(current, lease)) return false
         if (reason == ExecutionInvalidationReason.START_FAILED) {
             recoveryPublicationClaim = null
         } else {
@@ -927,9 +929,31 @@ internal class WorkoutExecutionGuard(
         true
     }
 
-    /** Atomically claims and invalidates an exact lease for a delayed reset. */
-    fun claimExpectedReset(lease: ExecutionLease): Boolean =
-        invalidate(lease, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)
+    fun invalidate(lease: ExecutionLease, reason: ExecutionInvalidationReason): Boolean =
+        withPlatformLock(teardownLock) {
+            invalidateLocked(lease, reason)
+        }
+
+    /** Atomically reserves the reset boundary, captures cleanup, and invalidates an exact lease. */
+    fun claimExpectedResetAndCaptureResetCleanupToken(lease: ExecutionLease): ResetCleanupToken? =
+        withPlatformLock(teardownLock) {
+            if (expectedResetClaim != null || !sameIdentity(currentLeaseRef.value, lease)) {
+                return@withPlatformLock null
+            }
+            supersedeRecoveryPublicationLocked()
+            val token = captureResetCleanupTokenLocked()
+            if (!invalidateLocked(lease, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)) {
+                return@withPlatformLock null
+            }
+            expectedResetClaim = lease
+            token
+        }
+
+    fun releaseExpectedResetClaim(lease: ExecutionLease) = withPlatformLock(teardownLock) {
+        if (sameIdentity(expectedResetClaim, lease)) {
+            expectedResetClaim = null
+        }
+    }
 
     fun commitResetCleanupIfNoSuccessor(
         token: ResetCleanupToken,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
@@ -436,7 +436,7 @@ internal class WorkoutExecutionGuard(
         allowNoCurrentAfterOwnedInvalidation: Boolean,
         expectedRestoredOwner: RestoredRuntimeOwnerToken? = null,
     ): RecoveryPublicationClaim? = withPlatformLock(teardownLock) {
-        if (jobOwnershipClosed || recoveryPublicationClaim != null) return@withPlatformLock null
+        if (jobOwnershipClosed || expectedResetClaim != null || recoveryPublicationClaim != null) return@withPlatformLock null
         if (recoveryPublicationSupersessionEpoch != expectedSupersessionEpoch) return@withPlatformLock null
         if (!recoveryPublicationAuthorityMatches(expectedLease, allowNoCurrentAfterOwnedInvalidation)) {
             return@withPlatformLock null
@@ -460,6 +460,7 @@ internal class WorkoutExecutionGuard(
         block: () -> Unit,
     ): Boolean = withPlatformLock(teardownLock) {
         if (jobOwnershipClosed ||
+            expectedResetClaim != null ||
             recoveryPublicationClaim != claim ||
             executionSequence.value != claim.executionGeneration ||
             recoveryPublicationSupersessionEpoch != claim.supersessionEpoch ||
@@ -500,6 +501,7 @@ internal class WorkoutExecutionGuard(
             claim.expectedLease != null ||
             claim.allowNoCurrentAfterOwnedInvalidation ||
             currentLeaseRef.value != null ||
+            expectedResetClaim != null ||
             restoredTeardownRecord != null ||
             machineConfigurationClaim != null ||
             configurationInputEpoch != expectedConfigurationInputEpoch ||

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
@@ -940,11 +940,8 @@ internal class WorkoutExecutionGuard(
             if (expectedResetClaim != null || !sameIdentity(currentLeaseRef.value, lease)) {
                 return@withPlatformLock null
             }
-            supersedeRecoveryPublicationLocked()
             val token = captureResetCleanupTokenLocked()
-            if (!invalidateLocked(lease, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)) {
-                return@withPlatformLock null
-            }
+            invalidateLocked(lease, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)
             expectedResetClaim = lease
             token
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
@@ -927,6 +927,10 @@ internal class WorkoutExecutionGuard(
         true
     }
 
+    /** Atomically claims and invalidates an exact lease for a delayed reset. */
+    fun claimExpectedReset(lease: ExecutionLease): Boolean =
+        invalidate(lease, ExecutionInvalidationReason.RESET_FOR_NEW_WORKOUT)
+
     fun commitResetCleanupIfNoSuccessor(
         token: ResetCleanupToken,
         invalidatedLease: ExecutionLease?,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
@@ -926,7 +926,7 @@ internal class WorkoutExecutionGuard(
             LogEventType.WORKOUT_EXECUTION,
             "executionId=${current.executionId},sessionId=${current.sessionId},transition=invalidated,reason=$reason",
         )
-        true
+        return true
     }
 
     fun invalidate(lease: ExecutionLease, reason: ExecutionInvalidationReason): Boolean =

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -41,6 +41,7 @@ import com.devil.phoenixproject.domain.model.RoutineLaunchOrigin
 import com.devil.phoenixproject.domain.model.SetEndReason
 import com.devil.phoenixproject.domain.model.SetType
 import com.devil.phoenixproject.domain.model.TrainingCycle
+import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WarmupSet
 import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutParameters
@@ -65,6 +66,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -3481,6 +3483,83 @@ class DWSMWorkoutLifecycleTest {
             assertFalse(lease.isTimedCable)
             assertIs<WorkoutState.Active>(harness.coordinator.workoutState.value)
         } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `Just Lift reset publishes Idle and egg timer before releasing reset claim`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            harness.setActiveProfilePreferences(
+                UserPreferences(autoStartCountdownSeconds = 2),
+            )
+            harness.setActiveSummaryCountdownSeconds(-1)
+            harness.fakeBleRepo.simulateConnect("Vee_Test")
+            harness.dwsm.updateWorkoutParameters(
+                TestFixtures.justLiftParams.copy(justLiftRestSeconds = 30),
+            )
+            harness.dwsm.startWorkout(skipCountdown = true, isJustLiftMode = true)
+            advanceUntilIdle()
+            val leaseA = harness.activeSessionEngine.currentExecutionLeaseForTest()
+            harness.coordinator._repCount.value = RepCount(workingReps = 1, isWarmupComplete = true)
+
+            var publicationObserved = false
+            harness.activeSessionEngine.afterJustLiftResetPresentationForTest = {
+                publicationObserved = true
+                assertIs<WorkoutState.Idle>(harness.coordinator.workoutState.value)
+                assertEquals(30, harness.coordinator.justLiftRestCountdown.value)
+
+                // A queued handle-grab/auto-start must not cross the reset claim while
+                // the post-reset Idle and egg-timer writes are being published.
+                harness.fakeBleRepo.setHandleState(HandleState.Grabbed)
+                advanceTimeBy(2_000)
+                runCurrent()
+                assertNull(harness.activeSessionEngine.currentExecutionLeaseOrNull())
+            }
+
+            harness.activeSessionEngine.handleSetCompletion(
+                leaseA,
+                SetEndReason.TARGET_REPS_REACHED,
+            )
+            runCurrent()
+
+            assertTrue(publicationObserved)
+            assertIs<WorkoutState.Idle>(harness.coordinator.workoutState.value)
+            assertEquals(28, harness.coordinator.justLiftRestCountdown.value)
+        } finally {
+            harness.activeSessionEngine.afterJustLiftResetPresentationForTest = null
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `Just Lift reset releases its claim when cleanup throws`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            harness.setActiveSummaryCountdownSeconds(-1)
+            harness.fakeBleRepo.simulateConnect("Vee_Test")
+            harness.dwsm.updateWorkoutParameters(TestFixtures.justLiftParams)
+            harness.dwsm.startWorkout(skipCountdown = true, isJustLiftMode = true)
+            advanceUntilIdle()
+            val leaseA = harness.activeSessionEngine.currentExecutionLeaseForTest()
+            harness.coordinator._repCount.value = RepCount(workingReps = 1, isWarmupComplete = true)
+            harness.activeSessionEngine.afterResetCleanupTokenCaptureForTest = {
+                error("test reset cleanup failure")
+            }
+
+            assertFailsWith<IllegalStateException> {
+                harness.activeSessionEngine.resetForNewWorkoutForTest(leaseA)
+            }
+            harness.activeSessionEngine.afterResetCleanupTokenCaptureForTest = null
+
+            // The failed reset must not wedge the guard and prevent all future starts.
+            harness.dwsm.updateWorkoutParameters(TestFixtures.justLiftParams)
+            harness.dwsm.startWorkout(skipCountdown = true, isJustLiftMode = true)
+            advanceUntilIdle()
+            assertNotEquals(leaseA, harness.activeSessionEngine.currentExecutionLeaseForTest())
+        } finally {
+            harness.activeSessionEngine.afterResetCleanupTokenCaptureForTest = null
             harness.cleanup()
         }
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
@@ -81,6 +82,32 @@ class WorkoutExecutionGuardTest {
         guard.releaseExpectedResetClaim(leaseA)
         val leaseB = guard.beginExecution(seed("session-b")).getOrThrow()
         assertTrue(guard.isCurrent(leaseB))
+    }
+
+    @Test
+    fun `expected reset claim blocks recovery publication until cleanup releases it`() {
+        val guard = WorkoutExecutionGuard()
+        val leaseA = guard.beginExecution(seed("session-a")).getOrThrow()
+        assertNotNull(guard.claimExpectedResetAndCaptureResetCleanupToken(leaseA))
+
+        val resetEpoch = guard.captureRecoveryPublicationEpoch()
+        assertNull(
+            guard.beginRecoveryPublication(
+                expectedLease = null,
+                expectedSupersessionEpoch = resetEpoch,
+                allowNoCurrentAfterOwnedInvalidation = false,
+            ),
+        )
+
+        guard.releaseExpectedResetClaim(leaseA)
+        val claim = assertNotNull(
+            guard.beginRecoveryPublication(
+                expectedLease = null,
+                expectedSupersessionEpoch = guard.captureRecoveryPublicationEpoch(),
+                allowNoCurrentAfterOwnedInvalidation = false,
+            ),
+        )
+        assertTrue(guard.commitRecoveryPublication(claim) {})
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
@@ -62,21 +62,10 @@ class WorkoutExecutionGuardTest {
         guard.invalidateCurrent(ExecutionInvalidationReason.STOP_SET)
         val leaseB = guard.beginExecution(seed("session-b")).getOrThrow()
 
-        assertFalse(guard.invalidate(leaseA, ExecutionInvalidationReason.START_FAILED))
+        assertFalse(guard.claimExpectedReset(leaseA))
         assertTrue(guard.isCurrent(leaseB))
         assertTrue(guard.invalidate(leaseB, ExecutionInvalidationReason.START_FAILED))
         assertFalse(guard.isCurrent(leaseB))
-    }
-
-    @Test
-    fun `expected reset claim fails without touching a successor`() {
-        val guard = WorkoutExecutionGuard()
-        val leaseA = guard.beginExecution(seed("session-a")).getOrThrow()
-        guard.invalidateCurrent(ExecutionInvalidationReason.STOP_SET)
-        val leaseB = guard.beginExecution(seed("session-b")).getOrThrow()
-
-        assertFalse(guard.claimExpectedReset(leaseA))
-        assertTrue(guard.isCurrent(leaseB))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
@@ -69,6 +69,17 @@ class WorkoutExecutionGuardTest {
     }
 
     @Test
+    fun `expected reset claim fails without touching a successor`() {
+        val guard = WorkoutExecutionGuard()
+        val leaseA = guard.beginExecution(seed("session-a")).getOrThrow()
+        guard.invalidateCurrent(ExecutionInvalidationReason.STOP_SET)
+        val leaseB = guard.beginExecution(seed("session-b")).getOrThrow()
+
+        assertFalse(guard.claimExpectedReset(leaseA))
+        assertTrue(guard.isCurrent(leaseB))
+    }
+
+    @Test
     fun `activation rejects a lease that is no longer current`() {
         val guard = WorkoutExecutionGuard()
         val leaseA = guard.beginExecution(seed("session-a")).getOrThrow()

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardTest.kt
@@ -5,6 +5,7 @@ package com.devil.phoenixproject.presentation.manager
 import com.devil.phoenixproject.domain.model.SetEndReason
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
@@ -62,10 +63,24 @@ class WorkoutExecutionGuardTest {
         guard.invalidateCurrent(ExecutionInvalidationReason.STOP_SET)
         val leaseB = guard.beginExecution(seed("session-b")).getOrThrow()
 
-        assertFalse(guard.claimExpectedReset(leaseA))
+        assertNull(guard.claimExpectedResetAndCaptureResetCleanupToken(leaseA))
         assertTrue(guard.isCurrent(leaseB))
         assertTrue(guard.invalidate(leaseB, ExecutionInvalidationReason.START_FAILED))
         assertFalse(guard.isCurrent(leaseB))
+    }
+
+    @Test
+    fun `expected reset claim reserves the boundary until cleanup releases it`() {
+        val guard = WorkoutExecutionGuard()
+        val leaseA = guard.beginExecution(seed("session-a")).getOrThrow()
+
+        val resetToken = guard.claimExpectedResetAndCaptureResetCleanupToken(leaseA)
+        assertEquals(leaseA, resetToken?.lease)
+        assertFails { guard.beginExecution(seed("session-b")).getOrThrow() }
+
+        guard.releaseExpectedResetClaim(leaseA)
+        val leaseB = guard.beginExecution(seed("session-b")).getOrThrow()
+        assertTrue(guard.isCurrent(leaseB))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- bind Just Lift completion resets to the exact completing execution lease
- skip stale completion state/egg-timer writes when a successor is current
- add guard regression coverage for stale reset claims

## Verification
- `git diff --cached --check` passed before commit
- Gradle test was attempted but this host has no Java runtime

Fixes #717