### PR TITLE
Consolidate brownfield packet #4: portal working-reps 1RM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,9 @@ Uses multiplatform-settings with Keychain backend (`KeychainSettings`) for secur
 - Requires iOS Keychain capability in entitlements
 
 ### 1RM Estimate Parity (PARITY-CRITICAL)
-- Canonical formula: hybrid — Brzycki `w*36/(37-reps)` for reps <= 10, Epley `w*(1+reps/30)` for reps > 10. Continuous at reps == 10.
-- Single implementation: `OneRepMaxCalculator.estimate()` (`util/Constants.kt`). All 1RM estimates (UI display, PR storage, cycle reporting) route through it — never reimplement the formula.
-- Mobile computes the estimate per exercise-session (per-cable kg) and ships it as `PortalExerciseDto.estimatedOneRepMaxKg`. The portal stores it verbatim in `exercise_progress.estimated_1rm_kg` and recomputes (same hybrid) ONLY when the field is absent (legacy payloads). Mirror any change in the phoenix-portal counterpart.
-- Max-weight PRs (`personal_records`) are a SEPARATE metric from the estimated 1RM — do not relabel one as the other.
+- Two estimators, plus a third column — never relabel one as another:
+  1. Hybrid rep-based 1RM — Brzycki `w*36/(37-reps)` for reps <= 10, Epley `w*(1+reps/30)` for reps > 10. Continuous at reps == 10. Single implementation: `OneRepMaxCalculator.estimate()` (`util/Constants.kt`). All hybrid estimates (UI display, PR storage, cycle reporting, portal DTO) route through it — never reimplement the formula.
+  2. Velocity OLS (VBT) — `VelocityOneRepMaxEstimator` from BLE mean concentric velocity. Shipped separately as `PortalExerciseDto.velocityEstimatedOneRepMaxKg`. Must never overwrite the hybrid field.
+  3. Max-weight PRs (`personal_records`) are a SEPARATE metric from either estimated 1RM.
+- Portal sync (mobile contract): compute the hybrid estimate per exercise-session from **workingReps** (fallback `totalReps` if working is 0), per-cable kg, and still ship it as `PortalExerciseDto.estimatedOneRepMaxKg`. Portal store-verbatim of that field is **unverified** — do not assert the portal writes it unchanged or skips recompute. Client remains drop-resistant.
 - Stored `Exercise.one_rep_max_kg` (manual 5/3/1 input or VBT assessment) is the fallback scaling baseline for `% of PR` routines when no matching PersonalRecord exists (`ResolveRoutineWeightsUseCase`).

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -347,13 +347,13 @@ object PortalSyncAdapter {
             name = session.exerciseName ?: "Unknown Exercise",
             muscleGroup = swr.muscleGroup,
             orderIndex = orderIndex,
-            // Per-cable estimate from this exercise's single set; matches the
-            // set's weightKg (per-cable). Portal applies its x2 display transform.
-            // null when there is no meaningful estimate (0-rep/0-weight) so the
-            // portal treats the field as absent and falls back, per the DTO doc.
+            // Per-cable hybrid 1RM from this exercise's single set. Uses
+            // workingReps (warmup excluded); falls back to totalReps when
+            // working is 0 (legacy rows). null when there is no meaningful
+            // estimate (0-rep/0-weight). Portal store-verbatim is unverified.
             estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(
                 session.weightPerCableKg,
-                session.totalReps,
+                session.workingReps.takeIf { it > 0 } ?: session.totalReps,
             ).takeIf { it > 0f },
             // Velocity-based (VBT) estimate, looked up by catalog exerciseId from
             // the precomputed map. Distinct from the rep-based estimate above; null

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -347,10 +347,8 @@ object PortalSyncAdapter {
             name = session.exerciseName ?: "Unknown Exercise",
             muscleGroup = swr.muscleGroup,
             orderIndex = orderIndex,
-            // Per-cable hybrid 1RM from this exercise's single set. Uses
-            // workingReps (warmup excluded); falls back to totalReps when
-            // working is 0 (legacy rows). null when there is no meaningful
-            // estimate (0-rep/0-weight). Portal store-verbatim is unverified.
+            // Working reps exclude warmup; fall back to totalReps when working
+            // is 0 so legacy rows still get an estimate.
             estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(
                 session.weightPerCableKg,
                 session.workingReps.takeIf { it > 0 } ?: session.totalReps,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -85,9 +85,10 @@ data class PortalExerciseDto(
     val orderIndex: Int = 0,
     /**
      * Canonical estimated 1RM (per-cable kg) for this exercise in this session.
-     * Mobile is the source of truth (see OneRepMaxCalculator.estimate). The
-     * portal stores this verbatim in exercise_progress.estimated_1rm_kg and
-     * only recomputes when this field is absent (legacy payloads).
+     * Mobile contract: OneRepMaxCalculator.estimate from workingReps, falling
+     * back to totalReps only when working is 0. Still shipped on every push.
+     * Portal store-verbatim of this field is unverified — do not assume the
+     * portal writes it unchanged or skips recompute.
      */
     val estimatedOneRepMaxKg: Float? = null,
     /**
@@ -97,8 +98,8 @@ data class PortalExerciseDto(
      * [estimatedOneRepMaxKg] (Brzycki/Epley hybrid) and must never overwrite it.
      * It is the latest passing estimate for this exercise/profile at push time
      * (a rolling current value, not as-of-session). Null when the exercise has
-     * no exerciseId or no passing velocity estimate. The portal stores this
-     * verbatim in exercise_progress.velocity_estimated_1rm_kg and never recomputes.
+     * no exerciseId or no passing velocity estimate. Portal store-verbatim of
+     * this field is unverified; do not assume the portal never recomputes it.
      */
     val velocityEstimatedOneRepMaxKg: Float? = null,
     val sets: List<PortalSetDto> = emptyList(),

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
@@ -12,6 +12,7 @@ import com.devil.phoenixproject.domain.model.Superset
 import com.devil.phoenixproject.domain.model.SupersetColors
 import com.devil.phoenixproject.domain.model.TrainingCycle
 import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.util.OneRepMaxCalculator
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -1080,23 +1081,71 @@ class PortalSyncAdapterTest {
     // ========== Estimated 1RM in sync payload (Task 4) ==========
 
     @Test
-    fun `exercise dto carries hybrid estimated 1RM per cable`() {
-        // 60 kg per cable x 5 reps -> Brzycki: 60 * 36 / 32 = 67.5
+    fun `exercise dto carries hybrid estimated 1RM from workingReps not warmup`() {
+        // 60 kg × 5 working + 3 warmup (totalReps=8). Must use working=5 → 67.5,
+        // not the 8-rep estimate. Leaving totalReps=5 / workingReps default 0
+        // would still pass after the working==0 fallback and would not prove D-6.
         val sessions = listOf(
             makeSessionWithReps(
                 sessionId = "s1",
                 routineSessionId = null,
                 exerciseName = "Bench Press",
                 weightPerCableKg = 60f,
-                totalReps = 5,
+                warmupReps = 3,
+                workingReps = 5,
+                totalReps = 8,
             ),
         )
 
         val result = PortalSyncAdapter.toPortalWorkoutSessions(sessions, "user-1")
 
         val estimate = result[0].exercises[0].estimatedOneRepMaxKg
+        val fromWorking = OneRepMaxCalculator.estimate(60f, 5)
+        val fromTotal = OneRepMaxCalculator.estimate(60f, 8)
         assertNotNull(estimate)
-        assertTrue(abs(estimate - 67.5f) < 0.01f, "expected 67.5, got $estimate")
+        assertFloatEquals(fromWorking, estimate)
+        assertFloatEquals(67.5f, estimate)
+        assertTrue(
+            abs(estimate - fromTotal) > 1f,
+            "warmup+working golden must not equal the 8-rep estimate ($fromTotal)",
+        )
+    }
+
+    @Test
+    fun `exercise dto hybrid 1RM falls back to totalReps when workingReps is 0`() {
+        val sessions = listOf(
+            makeSessionWithReps(
+                sessionId = "s1",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 60f,
+                workingReps = 0,
+                totalReps = 5,
+            ),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(sessions, "user-1")
+
+        assertFloatEquals(
+            OneRepMaxCalculator.estimate(60f, 5),
+            result[0].exercises[0].estimatedOneRepMaxKg!!,
+        )
+    }
+
+    @Test
+    fun `exercise dto hybrid 1RM is null when working and total reps are 0`() {
+        val sessions = listOf(
+            makeSessionWithReps(
+                sessionId = "s1",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 60f,
+                workingReps = 0,
+                totalReps = 0,
+            ),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(sessions, "user-1")
+
+        assertNull(result[0].exercises[0].estimatedOneRepMaxKg)
     }
 
     // ========== Velocity-estimated 1RM in sync payload (Phase 6) ==========
@@ -1188,6 +1237,8 @@ class PortalSyncAdapterTest {
         durationMs: Long = 60000,
         weightPerCableKg: Float = 20f,
         reps: Int = 10,
+        warmupReps: Int = 0,
+        workingReps: Int = 0,
         totalReps: Int = 10,
         totalVolumeKg: Float? = null,
         rpe: Int? = null,
@@ -1204,6 +1255,8 @@ class PortalSyncAdapterTest {
             weightPerCableKg = weightPerCableKg,
             duration = durationMs,
             totalReps = totalReps,
+            warmupReps = warmupReps,
+            workingReps = workingReps,
             exerciseName = exerciseName,
             exerciseId = exerciseId,
             routineSessionId = routineSessionId,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
@@ -1083,8 +1083,8 @@ class PortalSyncAdapterTest {
     @Test
     fun `exercise dto carries hybrid estimated 1RM from workingReps not warmup`() {
         // 60 kg × 5 working + 3 warmup (totalReps=8). Must use working=5 → 67.5,
-        // not the 8-rep estimate. Leaving totalReps=5 / workingReps default 0
-        // would still pass after the working==0 fallback and would not prove D-6.
+        // not the 8-rep estimate. A totalReps=5 / workingReps=0 fixture would
+        // still pass via fallback and would not prove working-over-warmup.
         val sessions = listOf(
             makeSessionWithReps(
                 sessionId = "s1",
@@ -1148,6 +1148,30 @@ class PortalSyncAdapterTest {
         assertNull(result[0].exercises[0].estimatedOneRepMaxKg)
     }
 
+    @Test
+    fun `exercise dto hybrid 1RM null does not drop a present velocity estimate`() {
+        val sessions = listOf(
+            makeSessionWithReps(
+                sessionId = "s1",
+                exerciseName = "Bench Press",
+                exerciseId = "ex1",
+                weightPerCableKg = 60f,
+                workingReps = 0,
+                totalReps = 0,
+            ),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(
+            sessions,
+            "user-1",
+            velocityEstimatesByExerciseId = mapOf("ex1" to 92f),
+        )
+
+        val exercise = result[0].exercises[0]
+        assertNull(exercise.estimatedOneRepMaxKg)
+        assertFloatEquals(92f, exercise.velocityEstimatedOneRepMaxKg!!)
+    }
+
     // ========== Velocity-estimated 1RM in sync payload (Phase 6) ==========
 
     @Test
@@ -1159,7 +1183,9 @@ class PortalSyncAdapterTest {
                 exerciseName = "Bench Press",
                 exerciseId = "ex1",
                 weightPerCableKg = 60f,
-                totalReps = 5,
+                warmupReps = 3,
+                workingReps = 5,
+                totalReps = 8,
             ),
         )
 
@@ -1170,10 +1196,15 @@ class PortalSyncAdapterTest {
         )
 
         val exercise = result[0].exercises[0]
+        val hybrid = exercise.estimatedOneRepMaxKg
         assertFloatEquals(92f, exercise.velocityEstimatedOneRepMaxKg!!)
-        // Rep-based estimate is still computed independently: 60 * 36 / 32 = 67.5
-        assertNotNull(exercise.estimatedOneRepMaxKg)
-        assertFloatEquals(67.5f, exercise.estimatedOneRepMaxKg!!)
+        // Hybrid stays independent and warmup-excluded: 60 × 5 working → 67.5
+        assertNotNull(hybrid)
+        assertFloatEquals(67.5f, hybrid)
+        assertTrue(
+            abs(hybrid - OneRepMaxCalculator.estimate(60f, 8)) > 1f,
+            "velocity fixture hybrid must not use the 8-rep (warmup-inclusive) estimate",
+        )
     }
 
     @Test
@@ -1238,7 +1269,7 @@ class PortalSyncAdapterTest {
         weightPerCableKg: Float = 20f,
         reps: Int = 10,
         warmupReps: Int = 0,
-        workingReps: Int = 0,
+        workingReps: Int? = null,
         totalReps: Int = 10,
         totalVolumeKg: Float? = null,
         rpe: Int? = null,
@@ -1256,7 +1287,7 @@ class PortalSyncAdapterTest {
             duration = durationMs,
             totalReps = totalReps,
             warmupReps = warmupReps,
-            workingReps = workingReps,
+            workingReps = workingReps ?: totalReps,
             exerciseName = exerciseName,
             exerciseId = exerciseId,
             routineSessionId = routineSessionId,


### PR DESCRIPTION
## Summary

- Consolidates brownfield scan `8951e31b` packet #4 onto current `main` (`4929c1e2f9cc98cfb6dcb08475cff3aebfe059b5`).
- This is consolidation of an unreviewed remote remediation branch; no other brownfield packets are included.
- Original commits:
  - `fc049dc522e1eb538b74f16841fe2ca78fd53eba` — `fix(sync): estimate portal 1RM from workingReps, demote store-verbatim`
  - `1ed8fd86df53f3f7a543d938e81ff248befd0efe` — `test(sync): pin portal 1RM fixtures to workingReps, not fallback`

## Behavior

- Portal exercise payloads calculate the canonical per-cable hybrid 1RM from `workingReps` when positive, falling back to `totalReps` only when `workingReps` is zero.
- Zero-weight/zero-rep estimates remain absent, without dropping a separate velocity estimate.
- DTO guidance no longer asserts unverified portal store-verbatim/recompute behavior.
- Portal sync fixtures explicitly cover warmup exclusion, the legacy fallback, zero-rep absence, and hybrid/VBT field separation.

## Verification

- `./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest --tests 'com.devil.phoenixproject.data.sync.PortalSyncAdapterTest'` — **PASS** (75 tests, 0 failures).
- `./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest` — **PASS** (3,729 tests, 0 failures).
- `./gradlew -Pskip.supabase.check=true :shared:compileKotlinIosArm64 :shared:compileTestKotlinIosArm64` — **PASS**.
- Packet patch comparison against the original range is byte-for-byte equivalent; final diff is limited to the four packet files.

Refs brownfield scan 8951e31b packet #4
