### PR TITLE
fix(ci): use matching Xcode for iOS archives

### DIFF
--- a/.github/workflows/ios-release-ipa.yml
+++ b/.github/workflows/ios-release-ipa.yml
@@ -93,6 +93,13 @@ jobs:
           # Show what was set
           grep "CURRENT_PROJECT_VERSION" iosApp/PhoenixApp/PhoenixApp.xcodeproj/project.pbxproj | head -2
 
+      # Keep Gradle/Kotlin/Native and xcodebuild on the same Xcode SDK. The macos-15
+      # runner does not include the iOS 18.2 simulator runtime that Xcode 16.2's
+      # actool expects for asset catalogs; Xcode 16.4 pairs with the installed iOS
+      # 18.5 runtime and retains the Xcode 16 App Store upload tooling.
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
       - name: Build shared framework and resources
         run: |
           # Single Gradle invocation — linkReleaseFrameworkIosArm64 already depends on
@@ -166,12 +173,6 @@ jobs:
         run: |
           mkdir -p shared/build/bin/iosArm64/debugFramework
           ln -sfn ../releaseFramework/shared.framework shared/build/bin/iosArm64/debugFramework/shared.framework
-
-      # macos-15 no longer includes the iOS 18.2 simulator runtime that Xcode 16.2's
-      # actool requires while compiling this asset catalog. Xcode 16.4 pairs with the
-      # installed iOS 18.5 runtime and retains the Xcode 16 App Store upload tooling.
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Install certificate and profile
         env:

--- a/.github/workflows/ios-release-ipa.yml
+++ b/.github/workflows/ios-release-ipa.yml
@@ -167,8 +167,11 @@ jobs:
           mkdir -p shared/build/bin/iosArm64/debugFramework
           ln -sfn ../releaseFramework/shared.framework shared/build/bin/iosArm64/debugFramework/shared.framework
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      # macos-15 no longer includes the iOS 18.2 simulator runtime that Xcode 16.2's
+      # actool requires while compiling this asset catalog. Xcode 16.4 pairs with the
+      # installed iOS 18.5 runtime and retains the Xcode 16 App Store upload tooling.
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Install certificate and profile
         env:

--- a/.github/workflows/ios-testflight-internal.yml
+++ b/.github/workflows/ios-testflight-internal.yml
@@ -153,8 +153,11 @@ jobs:
           mkdir -p shared/build/bin/iosArm64/debugFramework
           ln -sfn ../releaseFramework/shared.framework shared/build/bin/iosArm64/debugFramework/shared.framework
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      # macos-15 no longer includes the iOS 18.2 simulator runtime that Xcode 16.2's
+      # actool requires while compiling this asset catalog. Xcode 16.4 pairs with the
+      # installed iOS 18.5 runtime and retains the Xcode 16 App Store upload tooling.
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Install certificate and profile
         env:

--- a/.github/workflows/ios-testflight-internal.yml
+++ b/.github/workflows/ios-testflight-internal.yml
@@ -74,6 +74,13 @@ jobs:
           # Show what was set
           grep "CURRENT_PROJECT_VERSION" iosApp/PhoenixApp/PhoenixApp.xcodeproj/project.pbxproj | head -2
 
+      # Keep Gradle/Kotlin/Native and xcodebuild on the same Xcode SDK. The macos-15
+      # runner does not include the iOS 18.2 simulator runtime that Xcode 16.2's
+      # actool expects for asset catalogs; Xcode 16.4 pairs with the installed iOS
+      # 18.5 runtime and retains the Xcode 16 App Store upload tooling.
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
       - name: Build shared framework and resources
         run: |
           # Single Gradle invocation — linkReleaseFrameworkIosArm64 already depends on
@@ -152,12 +159,6 @@ jobs:
         run: |
           mkdir -p shared/build/bin/iosArm64/debugFramework
           ln -sfn ../releaseFramework/shared.framework shared/build/bin/iosArm64/debugFramework/shared.framework
-
-      # macos-15 no longer includes the iOS 18.2 simulator runtime that Xcode 16.2's
-      # actool requires while compiling this asset catalog. Xcode 16.4 pairs with the
-      # installed iOS 18.5 runtime and retains the Xcode 16 App Store upload tooling.
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Install certificate and profile
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -90,6 +90,13 @@ jobs:
           # Show what was set
           grep "CURRENT_PROJECT_VERSION" iosApp/PhoenixApp/PhoenixApp.xcodeproj/project.pbxproj | head -2
 
+      # Keep Gradle/Kotlin/Native and xcodebuild on the same Xcode SDK. The macos-15
+      # runner does not include the iOS 18.2 simulator runtime that Xcode 16.2's
+      # actool expects for asset catalogs; Xcode 16.4 pairs with the installed iOS
+      # 18.5 runtime and retains the Xcode 16 App Store upload tooling.
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
       - name: Build shared framework and resources
         run: |
           # Single Gradle invocation — linkReleaseFrameworkIosArm64 already depends on
@@ -168,12 +175,6 @@ jobs:
         run: |
           mkdir -p shared/build/bin/iosArm64/debugFramework
           ln -sfn ../releaseFramework/shared.framework shared/build/bin/iosArm64/debugFramework/shared.framework
-
-      # macos-15 no longer includes the iOS 18.2 simulator runtime that Xcode 16.2's
-      # actool requires while compiling this asset catalog. Xcode 16.4 pairs with the
-      # installed iOS 18.5 runtime and retains the Xcode 16 App Store upload tooling.
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Install certificate and profile
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -169,8 +169,11 @@ jobs:
           mkdir -p shared/build/bin/iosArm64/debugFramework
           ln -sfn ../releaseFramework/shared.framework shared/build/bin/iosArm64/debugFramework/shared.framework
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      # macos-15 no longer includes the iOS 18.2 simulator runtime that Xcode 16.2's
+      # actool requires while compiling this asset catalog. Xcode 16.4 pairs with the
+      # installed iOS 18.5 runtime and retains the Xcode 16 App Store upload tooling.
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Install certificate and profile
         env:


### PR DESCRIPTION
## Summary
- select Xcode 16.4 for all iOS archive workflows on macos-15
- avoid Xcode 16.2 actool failure caused by the runner image lacking the iOS 18.2 simulator runtime
- keep Xcode 16-era App Store upload tooling instead of reverting to Xcode 26

## Evidence
The latest iOS TestFlight run failed in CompileAssetCatalog with `iphonesimulator` SDK build 22C146, while the current macos-15 image provides the iOS 18.5 simulator runtime and Xcode 16.4.

## Verification
- `git diff --check`
- PyYAML parse of all touched and proxy release workflows
- GitHub Actions archive verification pending on this branch