### PR TITLE
fix(ios): use executeQuery for journal_mode WAL pragma

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -37,7 +37,9 @@ kotlin {
         withHostTest {}
     }
 
-    // iOS target (iosArm64 only - physical devices for distribution)
+    // iOS: iosArm64 is the distribution XCFramework. iosSimulatorArm64 is
+    // test-only so DriverFactory runtime contracts can run on a Mac without
+    // changing the shipped device framework.
     val xcf = XCFramework()
     iosArm64 {
         binaries.framework {
@@ -45,6 +47,17 @@ kotlin {
             isStatic = true
             xcf.add(this)
             // Link system frameworks required by shared module
+            linkerOpts("-framework", "HealthKit")
+            linkerOpts("-framework", "Speech")
+        }
+        binaries.all {
+            freeCompilerArgs += listOf("-Xadd-light-debug=enable")
+        }
+    }
+    iosSimulatorArm64 {
+        binaries.framework {
+            baseName = "shared"
+            isStatic = true
             linkerOpts("-framework", "HealthKit")
             linkerOpts("-framework", "Speech")
         }
@@ -174,11 +187,14 @@ kotlin {
 
         val iosArm64Main by getting
         val iosArm64Test by getting
+        val iosSimulatorArm64Main by getting
+        val iosSimulatorArm64Test by getting
 
         @Suppress("UNUSED_VARIABLE")
         val iosMain by creating {
             dependsOn(commonMain)
             iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
 
             dependencies {
                 // SQLDelight Native Driver
@@ -193,6 +209,7 @@ kotlin {
         val iosTest by creating {
             dependsOn(commonTest)
             iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
 
             dependencies {
                 implementation(libs.sqldelight.native.driver)

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/local/DriverFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/local/DriverFactory.ios.kt
@@ -58,7 +58,13 @@ actual class DriverFactory {
                 )
             }
 
-            driver.execute(null, "PRAGMA journal_mode = WAL", 0)
+            val journalMode = driver.queryText("PRAGMA journal_mode = WAL")
+            if (!journalMode.equals("wal", ignoreCase = true)) {
+                throw DatabaseFileMigrationException(
+                    DatabaseMigrationFailureCode.TARGET_VALIDATION_FAILED,
+                    "The Phoenix database journal mode is invalid.",
+                )
+            }
             driver.execute(null, "PRAGMA foreign_keys = ON", 0)
 
             val schemaVersion = driver.queryLong("PRAGMA user_version")
@@ -130,6 +136,23 @@ actual class DriverFactory {
         return value ?: throw DatabaseFileMigrationException(
             DatabaseMigrationFailureCode.TARGET_VALIDATION_FAILED,
             "The Phoenix database schema version could not be read.",
+        )
+    }
+
+    private fun SqlDriver.queryText(sql: String): String {
+        var value: String? = null
+        executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                if (cursor.next().value) value = cursor.getString(0)
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+        return value ?: throw DatabaseFileMigrationException(
+            DatabaseMigrationFailureCode.TARGET_VALIDATION_FAILED,
+            "The Phoenix database journal mode could not be read.",
         )
     }
 }

--- a/shared/src/iosTest/kotlin/com/devil/phoenixproject/data/local/Issue725FreshInstallDriverFactoryTest.kt
+++ b/shared/src/iosTest/kotlin/com/devil/phoenixproject/data/local/Issue725FreshInstallDriverFactoryTest.kt
@@ -1,0 +1,112 @@
+package com.devil.phoenixproject.data.local
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import co.touchlab.sqliter.DatabaseFileContext
+import com.devil.phoenixproject.database.PhoenixDatabase
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSFileManager
+
+/**
+ * Runtime regression for issue #725: iOS DriverFactory must open a clean
+ * filesystem database without throwing DB_TARGET_VALIDATION_FAILED.
+ *
+ * The production path is the system under test — do not substitute an
+ * in-memory NativeSqliteDriver here.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class Issue725FreshInstallDriverFactoryTest {
+    @BeforeTest
+    fun setUp() {
+        deleteAllPhoenixDatabaseArtifacts()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        deleteAllPhoenixDatabaseArtifacts()
+    }
+
+    @Test
+    fun createDriver_fromCleanFilesystem_enablesWalAndValidatesSchema47() {
+        val driver = DriverFactory().createDriver()
+        try {
+            assertEquals(47L, PhoenixDatabase.Schema.version)
+            assertEquals(PhoenixDatabase.Schema.version, driver.queryLong("PRAGMA user_version"))
+            assertEquals("wal", driver.queryText("PRAGMA journal_mode").lowercase())
+            assertEquals("ok", driver.queryText("PRAGMA quick_check").lowercase())
+        } finally {
+            driver.close()
+        }
+    }
+
+    @Test
+    fun createDriver_secondLaunch_reopensExistingWalDatabase() {
+        DriverFactory().createDriver().close()
+
+        val driver = DriverFactory().createDriver()
+        try {
+            assertEquals(PhoenixDatabase.Schema.version, driver.queryLong("PRAGMA user_version"))
+            assertEquals("wal", driver.queryText("PRAGMA journal_mode").lowercase())
+            assertEquals("ok", driver.queryText("PRAGMA quick_check").lowercase())
+        } finally {
+            driver.close()
+        }
+    }
+
+    private fun deleteAllPhoenixDatabaseArtifacts() {
+        val names = listOf(
+            DatabaseFileNames.LEGACY,
+            DatabaseFileNames.TARGET,
+            DatabaseFileNames.STAGING,
+            DatabaseFileNames.RECOVERY,
+            DatabaseFileNames.LOCK,
+        )
+        val suffixes = listOf("", "-wal", "-shm", "-journal")
+        val fileManager = NSFileManager.defaultManager
+        for (name in names) {
+            val base = DatabaseFileContext.databasePath(name, null)
+            for (suffix in suffixes) {
+                val path = "$base$suffix"
+                if (fileManager.fileExistsAtPath(path)) {
+                    check(fileManager.removeItemAtPath(path, error = null)) {
+                        "Could not delete database artifact at $path"
+                    }
+                }
+            }
+        }
+    }
+
+    private fun SqlDriver.queryLong(sql: String): Long {
+        var value: Long? = null
+        executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                check(cursor.next().value) { "Expected one row for $sql" }
+                value = cursor.getLong(0)
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+        return checkNotNull(value) { "$sql returned no value" }
+    }
+
+    private fun SqlDriver.queryText(sql: String): String {
+        var value: String? = null
+        executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                check(cursor.next().value) { "Expected one row for $sql" }
+                value = cursor.getString(0)
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+        return checkNotNull(value) { "$sql returned no value" }
+    }
+}


### PR DESCRIPTION
## Bug Description

iOS v1.0.2 cannot launch. Every fresh install and upgrade path dies with `DB_TARGET_VALIDATION_FAILED` because `DriverFactory.ios.kt` runs query-returning `PRAGMA journal_mode = WAL` through SQLDelight `SqlDriver.execute()`. SQLiter throws `Queries can be performed using SQLiteDatabase query or rawQuery methods only.` PR #711 moved that formerly swallowed exception into the fail-closed validation boundary.

Fixes #725

## Root Cause

`PRAGMA journal_mode = WAL` returns a result row (the effective journal mode). SQLiter requires `query`/`rawQuery` for that statement. The iOS driver used the non-query API. This is not corrupt user data and not a failed schema migration: clean-install reconciliation completes with 0 failures before the pragma call throws.

## Fix

- Consume `PRAGMA journal_mode = WAL` via `executeQuery` and require the returned mode to be `wal` (fail-closed if it is not).
- Keep `PRAGMA foreign_keys = ON` on the non-query `execute()` path.
- Do not suppress the exception or weaken data-preservation safeguards.
- Add a test-only `iosSimulatorArm64` target (not added to the distribution XCFramework) so this runtime contract can be exercised on a Mac.

## How to Verify

1. Clean filesystem: `./gradlew -Pskip.supabase.check=true :shared:iosSimulatorArm64Test --tests 'com.devil.phoenixproject.data.local.Issue725FreshInstallDriverFactoryTest'`
2. Confirm `PRAGMA user_version = 47`, `PRAGMA journal_mode = wal`, `PRAGMA quick_check = ok`.
3. Second launch of the same test reopens the existing WAL database.
4. `./gradlew -Pskip.supabase.check=true :shared:compileKotlinIosArm64 :shared:verifyCommonMainPhoenixDatabaseMigration :shared:validateSchemaManifest`

## Test Plan

- [x] Added iOS runtime regression test that calls the real `DriverFactory` from a clean filesystem
- [x] Red before: 1 test failed at `DriverFactory.ios.kt:61` with the SQLiter query-via-execute exception
- [x] Green after: 2 tests passed (`createDriver_fromCleanFilesystem_enablesWalAndValidatesSchema47`, `createDriver_secondLaunch_reopensExistingWalDatabase`)
- [x] `compileKotlinIosArm64` BUILD SUCCESSFUL
- [x] `verifyCommonMainPhoenixDatabaseMigration` BUILD SUCCESSFUL
- [x] `validateSchemaManifest` — 395 columns across 47 tables, all covered
- [x] `DatabaseFileMigrationCoordinatorTest` via `iosSimulatorArm64Test` BUILD SUCCESSFUL
- [ ] Android host schema tests (`testAndroidHostTest`) — not run here; Android SDK path is unavailable in this worker sandbox (`~/Library/Android/sdk` not visible). CI should run them. This change is iOS-only.
- [ ] Physical-device 0.9.6 → fixed-build upgrade (not available locally)

## Risk Assessment

Low — iOS-only pragma API correction. Fail-closed validation, recovery retention, and file-preservation behavior are unchanged. The XCFramework remains `iosArm64` only.

## Evidence

Red:
```
Queries can be performed using SQLiteDatabase query or rawQuery methods only.
at com.devil.phoenixproject.data.local.DriverFactory#createDriver(...DriverFactory.ios.kt:61)
```

Green:
```
./gradlew -Pskip.supabase.check=true :shared:iosSimulatorArm64Test --tests 'com.devil.phoenixproject.data.local.Issue725FreshInstallDriverFactoryTest'
BUILD SUCCESSFUL
```