### PR TITLE
fix(ios): do not treat WAL sidecars as dual databases

### DIFF
--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/local/IosDatabaseFileOperations.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/local/IosDatabaseFileOperations.kt
@@ -230,16 +230,18 @@ internal class IosDatabaseFileOperations(
         val compatibilitySidecars = existingSidecars(compatibilityPath)
         val legacySidecars = existingSidecars(legacyPath)
 
+        val legacyExists = fileManager.fileExistsAtPath(legacyPath)
+
         if (!compatibilityExists) {
-            if (compatibilitySidecars.isNotEmpty() || legacySidecars.isNotEmpty()) {
-                throw DatabaseFileMigrationException(
-                    DatabaseMigrationFailureCode.DUAL_DATABASES,
-                    "Orphaned legacy database sidecars exist without a legacy database; automatic recovery is disabled.",
-                )
+            if (compatibilitySidecars.isNotEmpty()) {
+                NSLog("iOS DB: Ignoring orphaned Library/vitruvian.db sidecars without a main file")
+            }
+            if (!legacyExists && legacySidecars.isNotEmpty()) {
+                NSLog("iOS DB: Ignoring orphaned SQLiter vitruvian.db sidecars without a main file")
             }
             return
         }
-        if (fileManager.fileExistsAtPath(legacyPath)) {
+        if (legacyExists) {
             throw DatabaseFileMigrationException(
                 DatabaseMigrationFailureCode.DUAL_DATABASES,
                 "Legacy database files exist in both the old and SQLiter locations; automatic recovery is disabled.",

--- a/shared/src/iosTest/kotlin/com/devil/phoenixproject/data/local/Issue725RecurrenceTest.kt
+++ b/shared/src/iosTest/kotlin/com/devil/phoenixproject/data/local/Issue725RecurrenceTest.kt
@@ -11,8 +11,10 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSFileManager
 
@@ -57,6 +59,124 @@ class Issue725RecurrenceTest {
 
         assertFalse(fileManager.fileExistsAtPath(legacyLibraryRootPath()))
         assertTrue(fileManager.fileExistsAtPath(DatabaseFileContext.databasePath(DatabaseFileNames.TARGET, null)))
+    }
+
+    @Test
+    fun sqliterLegacyDatabaseWithWalSidecarsDoesNotThrowDualDatabases() {
+        val legacyDriver = NativeSqliteDriver(
+            schema = PhoenixDatabase.Schema,
+            name = DatabaseFileNames.LEGACY,
+        )
+        legacyDriver.execute(
+            null,
+            "INSERT INTO UserProfile(id, name, colorIndex, createdAt, isActive) VALUES ('legacy-profile', 'Legacy', 0, 1, 1)",
+            0,
+        )
+        legacyDriver.close()
+
+        val sqliterLegacy = DatabaseFileContext.databasePath(DatabaseFileNames.LEGACY, null)
+        assertTrue(fileManager.fileExistsAtPath(sqliterLegacy))
+        assertFalse(fileManager.fileExistsAtPath(legacyLibraryRootPath()))
+        ensureSidecar(sqliterLegacy, "-wal")
+        ensureSidecar(sqliterLegacy, "-shm")
+
+        val layout = try {
+            IosDatabaseFileOperations().inspect()
+        } catch (failure: DatabaseFileMigrationException) {
+            fail("inspect threw ${failure.code} for a normal SQLiter legacy DB plus WAL sidecars: ${failure.message}")
+        }
+
+        assertTrue(layout.legacyExists)
+        assertFalse(layout.targetExists)
+    }
+
+    @Test
+    fun sqliterLegacyDatabaseWithWalSidecarsMigratesToPhoenixAndPreservesData() {
+        val legacyDriver = NativeSqliteDriver(
+            schema = PhoenixDatabase.Schema,
+            name = DatabaseFileNames.LEGACY,
+        )
+        legacyDriver.execute(
+            null,
+            "INSERT INTO UserProfile(id, name, colorIndex, createdAt, isActive) VALUES ('legacy-profile', 'Legacy', 0, 1, 1)",
+            0,
+        )
+        legacyDriver.close()
+
+        val sqliterLegacy = DatabaseFileContext.databasePath(DatabaseFileNames.LEGACY, null)
+        ensureSidecar(sqliterLegacy, "-wal")
+        ensureSidecar(sqliterLegacy, "-shm")
+
+        val driver = DriverFactory().createDriver()
+        try {
+            assertEquals("Legacy", queryScalar(driver, "SELECT name FROM UserProfile WHERE id = 'legacy-profile'"))
+        } finally {
+            driver.close()
+        }
+
+        assertFalse(fileManager.fileExistsAtPath(sqliterLegacy))
+        assertTrue(fileManager.fileExistsAtPath(DatabaseFileContext.databasePath(DatabaseFileNames.TARGET, null)))
+        assertFalse(fileManager.fileExistsAtPath(legacyLibraryRootPath()))
+    }
+
+    @Test
+    fun orphanSqliterLegacySidecarsWithoutMainDoNotBlockPhoenixOpen() {
+        val sqliterLegacy = DatabaseFileContext.databasePath(DatabaseFileNames.LEGACY, null)
+        ensureSidecar(sqliterLegacy, "-wal")
+        ensureSidecar(sqliterLegacy, "-shm")
+        assertFalse(fileManager.fileExistsAtPath(sqliterLegacy))
+        assertFalse(fileManager.fileExistsAtPath(legacyLibraryRootPath()))
+
+        val driver = DriverFactory().createDriver()
+        try {
+            assertEquals(PhoenixDatabase.Schema.version, queryLong(driver, "PRAGMA user_version"))
+        } finally {
+            driver.close()
+        }
+
+        assertTrue(fileManager.fileExistsAtPath(DatabaseFileContext.databasePath(DatabaseFileNames.TARGET, null)))
+        assertTrue(fileManager.fileExistsAtPath("$sqliterLegacy-wal"))
+        assertTrue(fileManager.fileExistsAtPath("$sqliterLegacy-shm"))
+    }
+
+    @Test
+    fun trueDualLibraryAndSqliterLegacyMainsStillBlockWithoutDeleting() {
+        val legacyDriver = NativeSqliteDriver(
+            schema = PhoenixDatabase.Schema,
+            name = DatabaseFileNames.LEGACY,
+        )
+        legacyDriver.execute(
+            null,
+            "INSERT INTO UserProfile(id, name, colorIndex, createdAt, isActive) VALUES ('dual-profile', 'Dual', 0, 1, 1)",
+            0,
+        )
+        legacyDriver.close()
+
+        val sqliterLegacy = DatabaseFileContext.databasePath(DatabaseFileNames.LEGACY, null)
+        val libraryLegacy = legacyLibraryRootPath()
+        assertTrue(fileManager.fileExistsAtPath(sqliterLegacy))
+        moveArtifact(sqliterLegacy, libraryLegacy)
+        check(fileManager.copyItemAtPath(libraryLegacy, toPath = sqliterLegacy, error = null)) {
+            "Could not copy Library legacy DB back to SQLiter path for dual-main fixture"
+        }
+        for (suffix in SIDECAR_SUFFIXES) {
+            val source = "$libraryLegacy$suffix"
+            val destination = "$sqliterLegacy$suffix"
+            if (fileManager.fileExistsAtPath(source) && !fileManager.fileExistsAtPath(destination)) {
+                check(fileManager.copyItemAtPath(source, toPath = destination, error = null)) {
+                    "Could not copy sidecar $suffix for dual-main fixture"
+                }
+            }
+        }
+
+        val failure = assertFailsWith<DatabaseFileMigrationException> {
+            IosDatabaseFileOperations().inspect()
+        }
+
+        assertEquals(DatabaseMigrationFailureCode.DUAL_DATABASES, failure.code)
+        assertTrue(fileManager.fileExistsAtPath(sqliterLegacy))
+        assertTrue(fileManager.fileExistsAtPath(libraryLegacy))
+        assertFalse(fileManager.fileExistsAtPath(DatabaseFileContext.databasePath(DatabaseFileNames.TARGET, null)))
     }
 
     @Test
@@ -267,6 +387,15 @@ class Issue725RecurrenceTest {
             deletePathAndSidecars(path)
         }
         deletePathAndSidecars(legacyLibraryRootPath())
+    }
+
+    private fun ensureSidecar(databasePath: String, suffix: String) {
+        val sidecarPath = "$databasePath$suffix"
+        if (!fileManager.fileExistsAtPath(sidecarPath)) {
+            check(fileManager.createFileAtPath(sidecarPath, contents = null, attributes = null)) {
+                "Could not create test sidecar at $sidecarPath"
+            }
+        }
     }
 
     private fun deletePathAndSidecars(path: String) {


### PR DESCRIPTION
Fixes #757

## Summary

TestFlight 1.0.2 (2026090419) shows non-retryable `DB_DUAL_DATABASES` even though PR #755 is in that build.

`migrateLegacyLibraryRootIfNeeded()` threw whenever SQLiter had `vitruvian.db` WAL sidecars and `Library/vitruvian.db` was absent. That Library path was never the live SQLiter location. The coordinator never got to migrate `vitruvian.db` → `phoenix.db`.

## What changed

- Return (log only) when the Library-root main file is missing.
- Still throw when both main files exist.
- Still throw when a Library main would be copied onto leftover SQLiter sidecars.
- Do not delete orphan sidecars.

## Verification

- RED then GREEN: `Issue725RecurrenceTest` new cases (SQLiter legacy+WAL, orphan sidecars, true dual mains).
- GREEN: existing `Issue725RecurrenceTest` (9 tests, 0 failures, parent `--rerun-tasks`).
- GREEN: `Issue725FreshInstallDriverFactoryTest` (2 tests, 0 failures).
- GREEN: `DatabaseFileMigrationCoordinatorTest` (23 tests, 0 failures).
- GREEN: `:shared:compileKotlinIosArm64`.

Android file-migration paths are untouched.
