### PR TITLE
fix: update Constants.APP_VERSION to 1.0.2

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
@@ -5,7 +5,7 @@ package com.devil.phoenixproject.util
  */
 object Constants {
     // App version
-    const val APP_VERSION = "1.0.0"
+    const val APP_VERSION = "1.0.2"
 
     // EULA version - increment when EULA text changes materially
     // Users must re-accept when this version increases


### PR DESCRIPTION
## Summary

`Constants.APP_VERSION` was still `"1.0.0"` while Android `versionName` and iOS `MARKETING_VERSION` are already `1.0.2`.

This caused the in-app version display, diagnostics export, and backup metadata to show `1.0.0` instead of `1.0.2`.

## Change

- `shared/src/commonMain/.../util/Constants.kt`: `APP_VERSION = "1.0.0"` → `"1.0.2"`

## Verification

- Android `versionName` in `androidApp/build.gradle.kts` is already `"1.0.2"` ✓
- iOS `MARKETING_VERSION` in `.xcodeproj/project.pbxproj` is already `1.0.2` ✓
- `Constants.APP_VERSION` now matches both platforms ✓