### PR TITLE
fix(ui): put Target Reps above Weight on routine set config (#767)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
@@ -706,8 +706,9 @@ private fun ExerciseOverviewCard(
                                     }
                                 }
                             } else {
-                                // Standard modes: Weight + Reps
-                                // Delta from routine baseline
+                                // Standard modes: Reps first, then Weight (Issue #767).
+                                // Matches RestTimerCard NEXT SET CONFIGURATION so users
+                                // don't swap reps/weight when hopping between screens.
                                 val baselineWeightKg = exercise.setWeightsPerCableKg.firstOrNull()
                                     ?: exercise.weightPerCableKg
                                 val deltaKg = adjustedWeight - baselineWeightKg
@@ -719,20 +720,6 @@ private fun ExerciseOverviewCard(
                                     null
                                 }
 
-                                SliderWithButtons(
-                                    value = adjustedWeight,
-                                    onValueChange = { newWeight ->
-                                        onWeightChange(newWeight.coerceIn(0f, maxWeightKg))
-                                    },
-                                    valueRange = 0f..maxWeightKg,
-                                    step = weightStepKg,
-                                    label = "Weight per cable",
-                                    formatValue = { formatWeight(it, weightUnit) },
-                                    deltaText = deltaText,
-                                    isDeltaPositive = deltaKg >= 0f,
-                                )
-
-                                // Reps adjuster (or AMRAP indicator)
                                 if (isAMRAP) {
                                     Row(
                                         modifier = Modifier.fillMaxWidth(),
@@ -759,6 +746,19 @@ private fun ExerciseOverviewCard(
                                         formatValue = { it.toInt().toString() },
                                     )
                                 }
+
+                                SliderWithButtons(
+                                    value = adjustedWeight,
+                                    onValueChange = { newWeight ->
+                                        onWeightChange(newWeight.coerceIn(0f, maxWeightKg))
+                                    },
+                                    valueRange = 0f..maxWeightKg,
+                                    step = weightStepKg,
+                                    label = "Weight per cable",
+                                    formatValue = { formatWeight(it, weightUnit) },
+                                    deltaText = deltaText,
+                                    isDeltaPositive = deltaKg >= 0f,
+                                )
                             }
                         }
                     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RoutineOverviewSetConfigOrderTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RoutineOverviewSetConfigOrderTest.kt
@@ -1,0 +1,81 @@
+package com.devil.phoenixproject.presentation
+
+import com.devil.phoenixproject.testutil.readProjectFile
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #767: SET CONFIGURATION field order must match Rest Timer
+ * (Target Reps before Weight per cable) so users don't adjust the
+ * opposite control when hopping between screens.
+ *
+ * Source-level wiring test follows RestTimerProgressionWiringTest /
+ * SetReadyScreenScrollWiringTest — this is a layout-order invariant,
+ * not a runtime Compose harness.
+ */
+class RoutineOverviewSetConfigOrderTest {
+
+    @Test
+    fun routineOverview_standardMode_rendersTargetRepsBeforeWeight() {
+        val src = readOverviewSource()
+        val standardBlock = extractStandardModeBlock(src)
+
+        val repsIdx = standardBlock.indexOf("label = \"Target Reps\"")
+        val amrapIdx = standardBlock.indexOf("stringResource(Res.string.target_reps)")
+        val weightIdx = standardBlock.indexOf("label = \"Weight per cable\"")
+
+        assertTrue(weightIdx >= 0, "Standard-mode SET CONFIGURATION must render Weight per cable.")
+        assertTrue(
+            repsIdx >= 0 || amrapIdx >= 0,
+            "Standard-mode SET CONFIGURATION must render Target Reps or the AMRAP target-reps row.",
+        )
+
+        val firstRepsIdx = listOf(repsIdx, amrapIdx).filter { it >= 0 }.minOrNull()
+            ?: error("Target Reps control missing from standard-mode block")
+        assertTrue(
+            firstRepsIdx < weightIdx,
+            "Issue #767: Target Reps must appear before Weight per cable in RoutineOverviewScreen " +
+                "standard-mode SET CONFIGURATION (canonical order matches RestTimerCard).",
+        )
+    }
+
+    @Test
+    fun restTimerCard_keepsCanonicalRepsBeforeWeightOrder() {
+        val src = readRestTimerSource()
+        val repsIdx = src.indexOf("Res.string.rest_target_reps")
+        val weightIdx = src.indexOf("Res.string.rest_weight_per_cable")
+
+        assertTrue(repsIdx >= 0, "RestTimerCard must render rest_target_reps.")
+        assertTrue(weightIdx >= 0, "RestTimerCard must render rest_weight_per_cable.")
+        assertTrue(
+            repsIdx < weightIdx,
+            "RestTimerCard NEXT SET CONFIGURATION is the canonical reps-first order; do not invert it.",
+        )
+    }
+
+    private fun extractStandardModeBlock(src: String): String {
+        val marker = "// Standard modes:"
+        val start = src.indexOf(marker)
+        assertTrue(start >= 0, "RoutineOverviewScreen must keep a Standard modes SET CONFIGURATION branch.")
+        val completedOverlay = src.indexOf("// Completed overlay", start)
+        val end = if (completedOverlay >= 0) completedOverlay else src.length
+        return src.substring(start, end)
+    }
+
+    private fun readOverviewSource(): String {
+        val src = readProjectFile(
+            "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt",
+        )
+        assertNotNull(src, "Could not locate RoutineOverviewScreen.kt")
+        return src
+    }
+
+    private fun readRestTimerSource(): String {
+        val src = readProjectFile(
+            "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt",
+        )
+        assertNotNull(src, "Could not locate RestTimerCard.kt")
+        return src
+    }
+}


### PR DESCRIPTION
## Summary

Standardizes SET CONFIGURATION field order on routine overview to match Rest Timer: **Target Reps**, then **Weight per cable**.

Closes #767.

Follows the maintainer feasibility note: reps-first on `RoutineOverviewScreen` standard-mode branch only. Slider/handle styling is left as a follow-up.

## Change

- `RoutineOverviewScreen.kt`: move Target Reps (or AMRAP row) above Weight per cable
- Source-level regression test so the order cannot silently flip back, and Rest Timer stays the canonical reps-first layout

## Test plan

- [x] Source-order test: `RoutineOverviewSetConfigOrderTest`
- [ ] Open a non-Echo routine on SET CONFIGURATION: Target Reps above Weight per cable
- [ ] Confirm Rest Timer NEXT SET CONFIGURATION is still reps-first
- [ ] Echo mode overview unchanged (Echo Level / Eccentric Load / Reps)

Contributed from [@Jdub7575](https://github.com/Jdub7575).

Made with [Cursor](https://cursor.com)